### PR TITLE
Update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,8 +6,8 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-max_line_length = off
+max_line_length = 100
 # 4 space indentation
 [*.{sv, svh, v, vhd}]
 indent_style = space
-indent_size = 4
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@
 - Name `generate` blocks with `begin : gen_name`. Do not put the name of the generate into a comment after the end; that's redundant. Do not use the `generate` keyword; it's redundant. For example:
 
     ```verilog
-    for (genvar i=0; i<10; i++) begin : gen_ten_times
+    for (genvar i=0; i < 10; i++) begin : gen_ten_times
       // something to generate 10x
     end
 
     if (PARAM == 0) begin : gen_no_param
       // something
-    end else begin: gen_param
+    end else begin : gen_param
       // something else
     end // param_gen
     ```

--- a/README.md
+++ b/README.md
@@ -133,15 +133,11 @@
     ```
     ```verilog
     module A (
-      input logic [11:0] address_i
+      input csr_addr_t csr_addr_i
     );
 
-      csr_addr_t csr_addr;
-
-      assign csr_addr = csr_addr_t'(address_i);
-
       always_comb begin
-        if (csr_addr.priv_lvl == PrivUser) begin
+        if (csr_addr_i.priv_lvl == PrivUser) begin
           // do something fancy with this signal
         end
       end

--- a/README.md
+++ b/README.md
@@ -2,46 +2,46 @@
 
 ## TL;DR - Absolute Minimum
 
-- If the existing coding style is sane, stick to it.
-- Avoid `defines` and `ifdefs` **as much as possible**.
-- Do not use tabs, use spaces.
-- Use 4 spaces to open a new indentation level.
-- Instantiation of modules should be prefixed with `i_`, e.g.: `i_prefetcher`.
-- For port definitions keep a post-fix direction (`_o`, `_i`, `_io`).
-- For active low signals put an additional (`n` for internal signals, `_no`, `_ni`, `_nio` for interface ones).
-- Denote output of a register with `_q` and the input with `_d`.
+- Use the `.sv` extension for SystemVerilog files and the `.svh` extension for SystemVerilog files that are `` `include``d.
+- Use only ASCII characters with Unix-style line endings (i.e., LF aka `\n`).
+- Wrap code at 100 characters per line.
+- Indent with two spaces per level. Do not use tabs.
+- Delete trailing whitespace at the end of every line. Delete trailing newlines at the end of every file. Every file ends with *exactly* one LF.
+- Use `begin` and `end` unless a statement fits on a single line. Put the `begin` on the same line as the condition and the `end` on its own line (where it may be followed by an `else`, see below).
+- Prefix module instances with `i_`, e.g.: `i_prefetcher`.
+- Append the direction to port names: `_o`, `_i`, `_io`.
+- For active-low signals put an additional `n`: `n` for internal signals, `_no`, `_ni`, `_nio` for ports.
+- Denote output of a register with `_q` and the input with `_d`. When pipelining a signal, append a number starting at 2, e.g., `_q2`.
+- Avoid `defines` and `ifdefs` **as much as possible**. Use parameters and packages instead.
+- If one file deviates from this style but consistently uses a different style, stick to the other style unless you are changing almost all code of that file.
 
 ## Naming
 
-|         Construct          |       Style        |
-|----------------------------|--------------------|
-| Declaration                | lower_snake_case   |
-| Instance names             | i_lower_snake_case |
-| Signals                    | lower_snake_case   |
-| Variable, functions, tasks | lower_snake_case   |
-| ```define``                | ALL_CAPS           |
-| Parameters                 | CamelCase          |
-| Constants                  | CamelCase          |
-| enumeration_types          | lower_snake_case_t |
-| Enumeration value names    | UpperCamelCase     |
+|         Construct          |       Style            |
+|----------------------------|------------------------|
+| Declaration                | `lower_snake_case`     |
+| Instance names             | `i_lower_snake_case`   |
+| Signals                    | `lower_snake_case`     |
+| Variable, functions, tasks | `lower_snake_case`     |
+| `` `define``               | `ALL_CAPS`             |
+| Tunable Parameters         | `CamelCase`            |
+| Constants                  | `ALL_CAPS`             |
+| Enumerated types           | `lower_snake_case_e`   |
+| Other `typedef`s           | `lower_snake_case_t`   |
+| Enumeration value names    | `UpperCamelCase`       |
+| Generate blocks            | `gen_lower_snake_case` |
 
 ## Files and Project Structure
 
-Each project must have two standard files, `<project>_top.sv` and  `<project>_pkg.sv`.
-- `<project>_top.sv` is the top-level of the IP
-- `<project>_pkg.sv` is the package containing all the global parameter of the design.
 - Each repository must contain a License file indicating the License at use.
 - Please link to this style guide if your project adheres to it.
-
-All project files and modules must be prefixed with  `<project>_*.sv`.
 
 ## Coding Style
 
 - Keep the files tidy. No superfluous line breaks, align ports on a common boundary.
-- Do not use tabs, use spaces. If you really want to use tabs, use them consistently.
 - Name dedicated signals wiring `module foo` (output) with `module bar` (input) `signal_foo_bar`
-- Within an IP, use Interfaces to connect component instances whenever possible.
-- Use Interfaces at the top-level interface of the IP, but also provide a wrapper that “unrolls” the Interfaces into input and output ports.
+- Use interfaces to connect component instances and *only* to connect instances. Do not perform logic operations on interface signals; various tools have bugs with it.
+- Use a flat port list (i.e., no interfaces) for modules. When a module is a reusable unit and has ports that can be represented as interfaces, provide a wrapper named `module_name_wrap` that exposes interfaces and does *nothing* else than connecting interfaces to the corresponding ports.
 - Do not put overly large comment headers. Nevertheless, try to structure your HDL code, e.g.:
 
     ```
@@ -51,117 +51,104 @@ All project files and modules must be prefixed with  `<project>_*.sv`.
     ```
 
 <!-- - Specify memory map and integration rules while coding, using the `crazy88` (TODO: Link to Documentation) syntax. -->
-- Put `begin` statements on the same level as the block qualifier, for example:
+- Put `begin` statements on the same level as the block qualifier (K&R style), for example:
 
     ```verilog
     module A (
-        input logic flush_i
+      input  logic flush_i,
+      output logic stall_o
     );
 
-        logic whatever_signal;
+      logic whatever_signal;
 
-        always_comb begin
-            if (flush_i) begin
-                // do some stuff here
-            end else if (whatever_signal) begin
-                // do some other stuff
-            end
+      always_comb begin
+        stall_o = 1'b0;
+        if (flush_i) begin
+          // do some stuff here
+          stall_o = 1'b1;
+        end else if (whatever_signal) begin
+          // do some other stuff
         end
+      end
     endmodule
     ```
-
-- The exception to the former rule are `always` blocks, where the `begin` can be placed on a new line, for example (K&R):
-
-    ```verilog
-    module A (
-        input logic flush_i
-    );
-
-        logic whatever_signal;
-
-        always_comb
-        begin
-            if (flush_i) begin
-                // do some stuff here
-            end else if (whatever_signal) begin
-                // do some other stuff
-            end
-        end
-    endmodule
-    ```
-
-- For `case`, always use `begin` and `end` and follow the K&R style:
-
-    ```verilog
-        case (foo_i)
-            8'h0 : begin
-                // case 0
-            end
-            8'h1 : begin
-                // case 1
-            end
-        endcase
-    ```
-
-- For `if`-`else` chains, use K&R style:
-
-    ```verilog
-        if (foo_i) begin
-            // do stuff
-        end else if (bar_i) begin
-            // do some other stuff
-        end
-    ```
-
     > The rationale is that extra lines for `begin/else/end` carry no information at all. They even may prevent parts of the code to not have enough space on some screens. Process blocks on the other hand are more self-contained and multiple process blocks are not required to be visible at the same time.
     > The intention behind this is to keep code which is closely related together (like the code in an `always` block). It then should easily fit on a single screen.
 
-- Give generics a meaningful type e.g.: `parameter int unsigned ASID_WIDTH = 1`. The default type is a signed integer which in most of the time does not make an awful lot of sense for hardware.
-- Always name control blocks within a `generate`:
+- This also applies to `case` statements.  `begin` and `end` may be omitted iff the entire case item (i.e., the case expression and the statement) fits on a single line.  Use a consistent style within one `case` statement.
 
     ```verilog
-        generate
-            for (genvar i=0; i<10; i++) begin : ten_times_gen
-                // something to generate 10x
-            end // ten_times_gen
-
-            if (PARAM == 0) begin : no_param_gen
-                // something
-            end // no_param_gen
-            else begin : param_gen
-                // something else
-            end // param_gen
-        endgenerate
+    unique case (state_q)
+      Idle: begin
+        state_d = Something;
+        valid_o = 1'b1;
+      end
+      Something: begin
+        // Multiple lines of other assignments
+        if (ready_i) begin
+          state_d = Idle;
+        end
+      end
+      default: begin
+        state_d = Idle;
+      end
+    endcase
     ```
-> This simplifies synthesis and back-end scripts significantly and make them more vendor independent.
-
--  Name `structs` which are used as types with a post-fix `_t`:
 
     ```verilog
+    unique case (stride_i)
+      2'd0: state_d = Idle;
+      2'd1: state_d = Bubble;
+      2'd2: state_d = Forward;
+      2'd3: state_d = Hold;
+    endcase
+    ```
+
+- Give generics a meaningful type e.g.: `parameter int unsigned AsidWidth = 1`. The default type is a signed integer which in most of the time does not make an awful lot of sense for hardware.
+
+- Name `generate` blocks with `begin : gen_name`. Do not put the name of the generate into a comment after the end; that's redundant. Do not use the `generate` keyword; it's redundant. For example:
+
+    ```verilog
+    for (genvar i=0; i<10; i++) begin : gen_ten_times
+      // something to generate 10x
+    end
+
+    if (PARAM == 0) begin : gen_no_param
+      // something
+    end else begin: gen_param
+      // something else
+    end // param_gen
+    ```
+    > This simplifies synthesis and back-end scripts significantly and make them more vendor independent.
+
+-  Name enumerate types with a `_e` suffix and `structs` that are used as types with a `_t` suffix:
+
+    ```verilog
+    typedef enum logic [1:0] { PrivUser, PrivSupervisor, PrivMachine } priv_lvl_e;
     typedef struct packed {
-        logic [1:0]  rw;
-        priv_lvl_t   priv_lvl;
-        logic  [7:0] address;
+      logic [1:0]  rw;
+      priv_lvl_e   priv_lvl;
+      logic  [7:0] address;
     } csr_addr_t;
     ```
     ```verilog
     module A (
-        input logic [11:0] address_i
+      input logic [11:0] address_i
     );
 
-        csr_addr_t csr_addr;
+      csr_addr_t csr_addr;
 
-        assign csr_addr = csr_addr_t'(address_i);
+      assign csr_addr = csr_addr_t'(address_i);
 
-        always_comb begin
-            if (csr_addr.priv_lvl == U_MODE) begin
-                // do something fancy with this signal
-            end
+      always_comb begin
+        if (csr_addr.priv_lvl == UMode) begin
+          // do something fancy with this signal
         end
+      end
     endmodule
     ```
 
-- Consider using [EditorConfig](http://editorconfig.org/):
+- Use [EditorConfig](http://editorconfig.org/) to make your editor consistently apply a style:
 
     ```
     # top-most EditorConfig file
@@ -172,18 +159,18 @@ All project files and modules must be prefixed with  `<project>_*.sv`.
     end_of_line = lf
     insert_final_newline = true
     trim_trailing_whitespace = true
-    max_line_length = off
-    # 4 space indentation
+    max_line_length = 100
+    # 2 space indentation
     [*.{sv, svh, v, vhd}]
     indent_style = space
-    indent_size = 4
+    indent_size = 2
     ```
 
     There are plug-ins for almost any sane editor. The same example `.editorconfig` can also be found in this repository.
 
-## Git Considerations
+## Git
 
-- Do not push to master, if you want to add a feature do it in your branch.
+- Do not push to master unless you are the owner (as in responsible) of a repository. If you want to contribute, create a branch and open a Pull Request.
 - Separate subject from body with a blank line.
 - Limit the subject line to 50 characters.
 - Capitalize the subject line.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 | Signals                    | `lower_snake_case`     |
 | Variable, functions, tasks | `lower_snake_case`     |
 | `` `define``               | `ALL_CAPS`             |
-| Tunable Parameters         | `CamelCase`            |
+| Tunable Parameters         | `UpperCamelCase`       |
 | Constants                  | `ALL_CAPS`             |
 | Enumerated types           | `lower_snake_case_e`   |
 | Other `typedef`s           | `lower_snake_case_t`   |

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@
       assign csr_addr = csr_addr_t'(address_i);
 
       always_comb begin
-        if (csr_addr.priv_lvl == UMode) begin
+        if (csr_addr.priv_lvl == PrivUser) begin
           // do something fancy with this signal
         end
       end

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **Append the direction to port names: `_o`, `_i`, `_io`.**
 - For **active-low signals** put an additional **`n`**: `n` for internal signals, `_no`, `_ni`, `_nio` for ports.
 - Denote **output** of a **register** with **`_q`** and the **input** with **`_d`**. When pipelining a signal, append a number starting at 2, e.g., `_q2`.
+- **All clock signals begin with `clk`.** The main system clock for a design is `clk`; the main clock input of a module is `clk_i`. All further clocks have a unique identifier appended (e.g., `clk_dram`) and all signals in that clock domain start with that identifier (e.g., `dram_addr`).
 - **Avoid `defines` and `ifdefs` as much as possible.** Use parameters and packages instead.
 - If one file deviates from this style but consistently uses a different style, stick to the other style unless you are changing almost all code of that file.
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@
     end
     ```
 
+- Use *logical* operators in *conditional* statements and *bitwise* operators when assigning signals or ports. For example:
+
+    ```verilog
+    always_comb begin
+      cnt_d = cnt_q;
+      if (push && !full) begin
+        cnt_d++;
+      end
+    end
+
+    assign flush = pop & ~empty;
+    ```
+
 - Use [EditorConfig](http://editorconfig.org/) to make your editor consistently apply a style:
 
     ```

--- a/README.md
+++ b/README.md
@@ -179,32 +179,6 @@
 - Use the present tense ("Add feature" not "Added feature").
 - Wrap the body at 72 characters.
 - Use the body to explain what and why vs. how.
-- Consider starting the commit message with an applicable emoji:
-    * :sparkles: `:sparkles:` When introducing a new feature
-    * :art: `:art:` Improving the format/structure of the code
-    * :zap: `:zap:` When improving performance
-    * :fire: `:fire` Removing code or files.
-    * :memo: `:memo:` When writing docs
-    * :bug: `:bug:` When fixing a bug
-    * :wastebasket: `:wastebasket:` When removing code or files
-    * :green_heart: `:green_heart:` When fixing the CI build
-    * :construction_worker: `:construction_worker:` Adding CI build system
-    * :white_check_mark: `:white_check_mark:` When adding tests
-    * :lock: `:lock:` When dealing with security
-    * :arrow_up: `:arrow_up:` When upgrading dependencies
-    * :arrow_down: `:arrow_down:` When downgrading dependencies
-    * :rotating_light: `:rotating_light:` When removing linter warnings
-    * :pencil2: `:pencil2:` Fixing typos
-    * :recycle: `:recycle:` Refactoring code.
-    * :boom: `:boom:` Introducing breaking changes
-    * :truck: `:truck:` Moving or renaming files.
-    * :space_invader: `:space_invader:` When fixing something synthesis related
-    * :beers: `:beer:` Writing code drunkenly.
-    * :ok_hand: `:ok_hand` Updating code due to code review changes
-    * :building_construction: `:building_construction:` Making architectural changes.
-    * :wrench: `:wrench:` Tooling
-    * :construction: `:construction:` Work In Progress WIP
-    * :bookmark: `:bookmark:` version tag
 
 For a detailed why and how please refer to one of the multiple [resources](https://chris.beams.io/posts/git-commit/) regarding git commit messages.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - For **active-low signals** put an additional **`n`**: `n` for internal signals, `_no`, `_ni`, `_nio` for ports.
 - Denote **output** of a **register** with **`_q`** and the **input** with **`_d`**. When pipelining a signal, append a number starting at 2, e.g., `_q2`.
 - **All clock signals begin with `clk`.** The main system clock for a design is `clk`; the main clock input of a module is `clk_i`. All further clocks have a unique identifier appended (e.g., `clk_dram`) and all signals in that clock domain start with that identifier (e.g., `dram_addr`).
+- **Resets are active-low and asynchronous.** **The default name is `rst_n`.**
 - **Avoid `defines` and `ifdefs` as much as possible.** Use parameters and packages instead.
 - If one file deviates from this style but consistently uses a different style, stick to the other style unless you are changing almost all code of that file.
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@
       // something
     end else begin : gen_param
       // something else
-    end // param_gen
+    end
     ```
     > This simplifies synthesis and back-end scripts significantly and make them more vendor independent.
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 ## TL;DR - Absolute Minimum
 
 - Use the `.sv` extension for SystemVerilog files and the `.svh` extension for SystemVerilog files that are `` `include``d.
-- Use only ASCII characters with Unix-style line endings (i.e., LF aka `\n`).
-- Wrap code at 100 characters per line.
-- Indent with two spaces per level. Do not use tabs.
-- Delete trailing whitespace at the end of every line. Delete trailing newlines at the end of every file. Every file ends with *exactly* one LF.
-- Use `begin` and `end` unless a statement fits on a single line. Put the `begin` on the same line as the condition and the `end` on its own line (where it may be followed by an `else`, see below).
-- Prefix module instances with `i_`, e.g.: `i_prefetcher`.
-- Append the direction to port names: `_o`, `_i`, `_io`.
-- For active-low signals put an additional `n`: `n` for internal signals, `_no`, `_ni`, `_nio` for ports.
-- Denote output of a register with `_q` and the input with `_d`. When pipelining a signal, append a number starting at 2, e.g., `_q2`.
-- Avoid `defines` and `ifdefs` **as much as possible**. Use parameters and packages instead.
+- Use **only ASCII characters** with **Unix-style line endings** (i.e., LF aka `\n`).
+- Wrap code at **100 characters per line**.
+- Indent with **two spaces** per level. **Do not use tabs.**
+- **Delete trailing whitespace** at the end of every line. **Delete trailing newlines** at the end of every file. **Every file ends with *exactly* one LF.**
+- Use `begin` and `end` unless a statement fits on a single line. Put the **`begin` on the same line as the condition** and the **`end` on its own line** (where it may be followed by an `else`, see below).
+- **Prefix module instances with `i_`**, e.g.: `i_prefetcher`.
+- **Append the direction to port names: `_o`, `_i`, `_io`.**
+- For **active-low signals** put an additional **`n`**: `n` for internal signals, `_no`, `_ni`, `_nio` for ports.
+- Denote **output** of a **register** with **`_q`** and the **input** with **`_d`**. When pipelining a signal, append a number starting at 2, e.g., `_q2`.
+- **Avoid `defines` and `ifdefs` as much as possible.** Use parameters and packages instead.
 - If one file deviates from this style but consistently uses a different style, stick to the other style unless you are changing almost all code of that file.
 
 ## Naming

--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@
     endmodule
     ```
 
+- Do not compare single-bit signals to `0` or `1`; that's redundant. Instead simply use the signal and unary logical negation, as in
+
+    ```verilog
+    if (valid_i && !ready_i) begin
+      state_d = Stall;
+    end
+    ```
+
 - Use [EditorConfig](http://editorconfig.org/) to make your editor consistently apply a style:
 
     ```


### PR DESCRIPTION
I need to share our Style Guide with partners for a project, but I noticed that it is outdated.

Here is an update to align with the settled points of the internal document. Additionally, I suggest we
- [remove commit emojis](https://github.com/pulp-platform/style-guidelines/commit/ae0e8833b99bf6020844fc3839be02074de01100) with the rationale that they are an a exotic outlier compared to the minimal/sober points the rest of the style guide establishes. They are not forbidden and can still be encouraged on a per-project basis if the owner prefers them.
- [make the essential TLDR items bold](https://github.com/pulp-platform/style-guidelines/commit/92ffbaf166bee0d11185a70a4fe9c7002d29001d) so that they immediately scream at the reader.